### PR TITLE
feat(data/int|nat/modeq): add `modneq` notation

### DIFF
--- a/src/data/int/modeq.lean
+++ b/src/data/int/modeq.lean
@@ -28,6 +28,12 @@ def modeq (n a b : ℤ) := a % n = b % n
 
 notation a ` ≡ `:50 b ` [ZMOD `:50 n `]`:0 := modeq n a b
 
+/-- `a ≢ b [ZMOD n]` when `a % n ≠ b % n`. -/
+@[derive decidable]
+def modneq (n a b : ℕ) := a % n ≠ b % n
+
+notation a ` ≢ `:50 b ` [ZMOD `:50 n `]`:0 := modneq n a b
+
 variables {m n a b c d : ℤ}
 
 namespace modeq

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -31,6 +31,12 @@ def modeq (n a b : ℕ) := a % n = b % n
 
 notation a ` ≡ `:50 b ` [MOD `:50 n `]`:0 := modeq n a b
 
+/-- Not valid modular congruence. `n.modneq a b`, or `a ≢ b [MOD n]`, means that `a - b` is NOT a multiple of `n`. -/
+@[derive decidable]
+def modneq (n a b : ℕ) := a % n ≠ b % n
+
+notation a ` ≢ `:50 b ` [MOD `:50 n `]`:0 := modneq n a b
+
 variables {m n a b c d : ℕ}
 
 namespace modeq


### PR DESCRIPTION
This PR will allow to do stuff like:

```

example : 15 ≡ 3 [MOD 12] := by norm_num [modeq]
example : 19 ≢ 6 [MOD 11] := by norm_num [modneq]
```

and

```
example : 15 ≡ 3 [ZMOD 12] := by norm_num [modeq]
example : 19 ≢ 6 [ZMOD 11] := by norm_num [modneq]

```
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
